### PR TITLE
Add `DeletePolicyIdentity` endpoint to `Access`

### DIFF
--- a/proto/gk/v1/access.proto
+++ b/proto/gk/v1/access.proto
@@ -44,7 +44,7 @@ service Access {
 		};
 	}
 
-	rpc DeletePolicyIdentity(AccessDeletePolicyIdentityRequest) returns (google.protobuf.Empty) {
+	rpc RemovePolicyIdentity(AccessRemovePolicyIdentityRequest) returns (google.protobuf.Empty) {
 		option (google.api.http) = {
 			delete : "/v1/access-policies/{policy_id}/identities"
 		};
@@ -107,7 +107,7 @@ message AccessAddPolicyIdentityRequest {
 
 message AccessAddPolicyIdentityResponse {}
 
-message AccessDeletePolicyIdentityRequest {
+message AccessRemovePolicyIdentityRequest {
 	string policy_id   = 1;
 	string identity_id = 2;
 }

--- a/proto/gk/v1/access.proto
+++ b/proto/gk/v1/access.proto
@@ -4,6 +4,7 @@ package gk.v1;
 
 import "gk/v1/common.proto";
 import "google/api/annotations.proto";
+import "google/protobuf/empty.proto";
 import "google/protobuf/struct.proto";
 
 service Access {
@@ -40,6 +41,12 @@ service Access {
 		option (google.api.http) = {
 			post : "/v1/access-policies/{policy_id}/identities"
 			body : "*"
+		};
+	}
+
+	rpc DeletePolicyIdentity(AccessDeletePolicyIdentityRequest) returns (google.protobuf.Empty) {
+		option (google.api.http) = {
+			delete : "/v1/access-policies/{policy_id}/identities"
 		};
 	}
 }
@@ -99,3 +106,8 @@ message AccessAddPolicyIdentityRequest {
 }
 
 message AccessAddPolicyIdentityResponse {}
+
+message AccessDeletePolicyIdentityRequest {
+	string policy_id   = 1;
+	string identity_id = 2;
+}

--- a/proto/gk/v1/access.proto
+++ b/proto/gk/v1/access.proto
@@ -44,7 +44,7 @@ service Access {
 		};
 	}
 
-	rpc RemovePolicyIdentity(AccessRemovePolicyIdentityRequest) returns (google.protobuf.Empty) {
+	rpc RemovePolicyIdentity(AccessRemovePolicyIdentityRequest) returns (AccessRemovePolicyIdentityResponse) {
 		option (google.api.http) = {
 			delete : "/v1/access-policies/{policy_id}/identities"
 		};
@@ -110,4 +110,7 @@ message AccessAddPolicyIdentityResponse {}
 message AccessRemovePolicyIdentityRequest {
 	string policy_id   = 1;
 	string identity_id = 2;
+}
+
+message AccessRemovePolicyIdentityResponse {
 }

--- a/src/datastore/access-policies.cpp
+++ b/src/datastore/access-policies.cpp
@@ -93,6 +93,29 @@ void AccessPolicy::addIdentity(const AccessPolicy::identity_t &id) const {
 	}
 }
 
+void AccessPolicy::deleteIdentity(const AccessPolicy::identity_t &id) const {
+	std::string_view qry = R"(
+		delete from "access-policies_identities"
+		where (policy_id, identity_id) = ($1::text, $2::text);
+	)";
+
+	try {
+		pg::exec(qry, _data.id, id);
+	} catch (pg::fkey_violation_t &) {
+		throw err::DatastoreInvalidAccessPolicyOrIdentity();
+	}
+
+	for (const auto &rule : _data.rules) {
+		Cache cache({
+			.identity = id,
+			.policy   = _data.id,
+			.rule     = rule,
+		});
+
+		cache.discard();
+	}
+}
+
 const AccessPolicy::collections_t AccessPolicy::collections() const {
 	std::string qry = R"(
 		select

--- a/src/datastore/access-policies.cpp
+++ b/src/datastore/access-policies.cpp
@@ -93,7 +93,7 @@ void AccessPolicy::addIdentity(const AccessPolicy::identity_t &id) const {
 	}
 }
 
-void AccessPolicy::deleteIdentity(const AccessPolicy::identity_t &id) const {
+void AccessPolicy::removeIdentity(const AccessPolicy::identity_t &id) const {
 	std::string_view qry = R"(
 		delete from "access-policies_identities"
 		where (policy_id, identity_id) = ($1::text, $2::text);

--- a/src/datastore/access-policies.h
+++ b/src/datastore/access-policies.h
@@ -65,7 +65,7 @@ public:
 
 	const identities_t identities(bool expand = false) const;
 	void               addIdentity(const identity_t &id) const;
-	void               deleteIdentity(const identity_t &id) const;
+	void               removeIdentity(const identity_t &id) const;
 
 	const Data::name_t &name() const noexcept { return _data.name; }
 	void                name(const std::string &name) noexcept { _data.name = name; }

--- a/src/datastore/access-policies.h
+++ b/src/datastore/access-policies.h
@@ -65,6 +65,7 @@ public:
 
 	const identities_t identities(bool expand = false) const;
 	void               addIdentity(const identity_t &id) const;
+	void               deleteIdentity(const identity_t &id) const;
 
 	const Data::name_t &name() const noexcept { return _data.name; }
 	void                name(const std::string &name) noexcept { _data.name = name; }

--- a/src/events/concepts.h
+++ b/src/events/concepts.h
@@ -5,7 +5,9 @@
 
 namespace events {
 template <typename T>
-concept encodable = requires(T t) { t.encode(); };
+concept encodable = requires(T t) {
+	t.encode();
+};
 
 template <typename T>
 concept serializable = requires(T t) {

--- a/src/events/concepts.h
+++ b/src/events/concepts.h
@@ -5,9 +5,7 @@
 
 namespace events {
 template <typename T>
-concept encodable = requires(T t) {
-	t.encode();
-};
+concept encodable = requires(T t) { t.encode(); };
 
 template <typename T>
 concept serializable = requires(T t) {

--- a/src/svc/access.cpp
+++ b/src/svc/access.cpp
@@ -94,14 +94,14 @@ grpc::ServerUnaryReactor *Access::CreatePolicy(
 	return reactor;
 }
 
-grpc::ServerUnaryReactor *Access::DeletePolicyIdentity(
-	grpc::CallbackServerContext *context, const gk::v1::AccessDeletePolicyIdentityRequest *request,
+grpc::ServerUnaryReactor *Access::RemovePolicyIdentity(
+	grpc::CallbackServerContext *context, const gk::v1::AccessRemovePolicyIdentityRequest *request,
 	google::protobuf::Empty *response) {
 	auto *reactor = context->DefaultReactor();
 
 	// TODO: error handling
 	auto policy = datastore::RetrieveAccessPolicy(request->policy_id());
-	policy.deleteIdentity(request->identity_id());
+	policy.removeIdentity(request->identity_id());
 
 	reactor->Finish(grpc::Status::OK);
 	return reactor;

--- a/src/svc/access.cpp
+++ b/src/svc/access.cpp
@@ -96,7 +96,7 @@ grpc::ServerUnaryReactor *Access::CreatePolicy(
 
 grpc::ServerUnaryReactor *Access::RemovePolicyIdentity(
 	grpc::CallbackServerContext *context, const gk::v1::AccessRemovePolicyIdentityRequest *request,
-	google::protobuf::Empty *response) {
+	gk::v1::AccessRemovePolicyIdentityResponse *response) {
 	auto *reactor = context->DefaultReactor();
 
 	// TODO: error handling

--- a/src/svc/access.cpp
+++ b/src/svc/access.cpp
@@ -94,6 +94,19 @@ grpc::ServerUnaryReactor *Access::CreatePolicy(
 	return reactor;
 }
 
+grpc::ServerUnaryReactor *Access::DeletePolicyIdentity(
+	grpc::CallbackServerContext *context, const gk::v1::AccessDeletePolicyIdentityRequest *request,
+	google::protobuf::Empty *response) {
+	auto *reactor = context->DefaultReactor();
+
+	// TODO: error handling
+	auto policy = datastore::RetrieveAccessPolicy(request->policy_id());
+	policy.deleteIdentity(request->identity_id());
+
+	reactor->Finish(grpc::Status::OK);
+	return reactor;
+}
+
 grpc::ServerUnaryReactor *Access::RetrievePolicy(
 	grpc::CallbackServerContext *context, const gk::v1::AccessRetrievePolicyRequest *request,
 	gk::v1::AccessPolicy *response) {

--- a/src/svc/access.h
+++ b/src/svc/access.h
@@ -23,9 +23,9 @@ public:
 		grpc::CallbackServerContext *context, const gk::v1::AccessCreatePolicyRequest *request,
 		gk::v1::AccessPolicy *response) override;
 
-	grpc::ServerUnaryReactor *DeletePolicyIdentity(
+	grpc::ServerUnaryReactor *RemovePolicyIdentity(
 		grpc::CallbackServerContext                     *context,
-		const gk::v1::AccessDeletePolicyIdentityRequest *request,
+		const gk::v1::AccessRemovePolicyIdentityRequest *request,
 		google::protobuf::Empty                         *response) override;
 
 	grpc::ServerUnaryReactor *RetrievePolicy(

--- a/src/svc/access.h
+++ b/src/svc/access.h
@@ -26,7 +26,7 @@ public:
 	grpc::ServerUnaryReactor *RemovePolicyIdentity(
 		grpc::CallbackServerContext                     *context,
 		const gk::v1::AccessRemovePolicyIdentityRequest *request,
-		google::protobuf::Empty                         *response) override;
+		gk::v1::AccessRemovePolicyIdentityResponse      *response) override;
 
 	grpc::ServerUnaryReactor *RetrievePolicy(
 		grpc::CallbackServerContext *context, const gk::v1::AccessRetrievePolicyRequest *request,

--- a/src/svc/access.h
+++ b/src/svc/access.h
@@ -23,6 +23,11 @@ public:
 		grpc::CallbackServerContext *context, const gk::v1::AccessCreatePolicyRequest *request,
 		gk::v1::AccessPolicy *response) override;
 
+	grpc::ServerUnaryReactor *DeletePolicyIdentity(
+		grpc::CallbackServerContext                     *context,
+		const gk::v1::AccessDeletePolicyIdentityRequest *request,
+		google::protobuf::Empty                         *response) override;
+
 	grpc::ServerUnaryReactor *RetrievePolicy(
 		grpc::CallbackServerContext *context, const gk::v1::AccessRetrievePolicyRequest *request,
 		gk::v1::AccessPolicy *response) override;

--- a/src/svc/access_test.cpp
+++ b/src/svc/access_test.cpp
@@ -298,7 +298,7 @@ TEST_F(svc_AccessTest, RemovePolicyIdentity) {
 
 		grpc::CallbackServerContext           ctx;
 		grpc::testing::DefaultReactorTestPeer peer(&ctx);
-		google::protobuf::Empty               response;
+		gk::v1::AccessRemovePolicyIdentityResponse response;
 
 		gk::v1::AccessRemovePolicyIdentityRequest request;
 		request.set_policy_id(policy.id());

--- a/src/svc/access_test.cpp
+++ b/src/svc/access_test.cpp
@@ -279,18 +279,18 @@ TEST_F(svc_AccessTest, CreatePolicy) {
 	}
 }
 
-TEST_F(svc_AccessTest, DeletePolicyIdentity) {
+TEST_F(svc_AccessTest, RemovePolicyIdentity) {
 	svc::Access svc;
 
-	// Success: delete identity
+	// Success: Remove identity
 	{
 		const datastore::Identity identity({
-			.sub = "sub:svc_AccessTest.DeletePolicyIdentity",
+			.sub = "sub:svc_AccessTest.RemovePolicyIdentity",
 		});
 		ASSERT_NO_THROW(identity.store());
 
 		const datastore::AccessPolicy policy({
-			.name = "name:svc_AccessTest.DeletePolicyIdentity",
+			.name = "name:svc_AccessTest.RemovePolicyIdentity",
 		});
 		ASSERT_NO_THROW(policy.store());
 		ASSERT_NO_THROW(policy.addIdentity(identity.id()));
@@ -300,11 +300,11 @@ TEST_F(svc_AccessTest, DeletePolicyIdentity) {
 		grpc::testing::DefaultReactorTestPeer peer(&ctx);
 		google::protobuf::Empty               response;
 
-		gk::v1::AccessDeletePolicyIdentityRequest request;
+		gk::v1::AccessRemovePolicyIdentityRequest request;
 		request.set_policy_id(policy.id());
 		request.set_identity_id(identity.id());
 
-		auto reactor = svc.DeletePolicyIdentity(&ctx, &request, &response);
+		auto reactor = svc.RemovePolicyIdentity(&ctx, &request, &response);
 		EXPECT_TRUE(peer.test_status_set());
 		EXPECT_TRUE(peer.test_status().ok());
 		EXPECT_EQ(peer.reactor(), reactor);


### PR DESCRIPTION
- (proto) add `DeletePolicyIdentity` endpoint
- (datastore) `AccessPolicy.deleteIdentity`
- (svc) `Access.DeletePolicyIdentity`
