### PR TITLE
Log and exit for unhandled exceptions potentially related to redis

### DIFF
--- a/src/svc/access.cpp
+++ b/src/svc/access.cpp
@@ -1,6 +1,7 @@
 #include "access.h"
 
 #include "err/errors.h"
+#include "logger/logger.h"
 
 namespace svc {
 grpc::ServerUnaryReactor *Access::AddPolicyCollection(
@@ -44,6 +45,10 @@ grpc::ServerUnaryReactor *Access::Check(
 		const auto policies =
 			datastore::AccessPolicy::Cache::check(request->identity_id(), request->resource());
 		map(policies, response);
+	} catch (const std::exception &e) {
+		// FIXME: added to help debug unhandled exceptions, should be removed.
+		logger::critical("svc", "exception", e.what());
+		return reactor;
 	} catch (...) {
 		reactor->Finish(grpc::Status(grpc::StatusCode::UNAVAILABLE, "Failed to check access"));
 		return reactor;

--- a/src/svc/rbac.cpp
+++ b/src/svc/rbac.cpp
@@ -1,6 +1,7 @@
 #include "rbac.h"
 
 #include "err/errors.h"
+#include "logger/logger.h"
 
 namespace svc {
 grpc::ServerUnaryReactor *Rbac::Check(
@@ -18,6 +19,10 @@ grpc::ServerUnaryReactor *Rbac::Check(
 		const auto policies =
 			datastore::RbacPolicy::Cache::check(request->identity_id(), request->permission());
 		map(policies, response);
+	} catch (const std::exception &e) {
+		// FIXME: added to help debug unhandled exceptions, should be removed.
+		logger::critical("svc", "exception", e.what());
+		return reactor;
 	} catch (...) {
 		reactor->Finish(grpc::Status(grpc::StatusCode::UNAVAILABLE, "Failed to check rbac"));
 		return reactor;


### PR DESCRIPTION
It seems when the redis connection is in a bad state the server can't recover. As a temporary measure, log potentially unhandled exceptions related to redis and exit.